### PR TITLE
Remove second arg from spl_autoload_register, in accordance with PHP8 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GatherContent Plugin -- Version 3.2.16 #
+# GatherContent Plugin -- Version 3.2.17 #
 
 This plugin allows you to transfer content from your GatherContent projects into your WordPress site and vice-versa.
 
@@ -46,6 +46,9 @@ Below the text box is a button that will allow you to simply save all of that in
 
 
 ## Changelog ##
+
+### 3.2.17 ###
+* Updated `spl_autoload_register` to be PHP8 compatible
 
 ### 3.2.16 ###
 * Reformatting version file

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "gathercontent/wp-importer",
   "description": "Imports items from GatherContent to your wordpress site",
-  "version": "3.2.16",
+  "version": "3.2.17",
   "type": "wordpress-plugin",
   "keywords": [],
   "homepage": "http://www.gathercontent.com",

--- a/gathercontent-importer.php
+++ b/gathercontent-importer.php
@@ -3,7 +3,7 @@
  * Plugin Name:  GatherContent Plugin
  * Plugin URI:   http://www.gathercontent.com
  * Description:  Imports items from GatherContent to your wordpress site
- * Version:      3.2.16
+ * Version:      3.2.17
  * Author:       GatherContent
  * Requires PHP: 7.0
  * Author URI:   http://www.gathercontent.com
@@ -31,8 +31,8 @@
  */
 
 // Useful global constants
-define( 'GATHERCONTENT_VERSION', '3.2.16' );
-define( 'GATHERCONTENT_ENQUEUE_VERSION', '3.2.16' );
+define( 'GATHERCONTENT_VERSION', '3.2.17' );
+define( 'GATHERCONTENT_ENQUEUE_VERSION', '3.2.17' );
 define( 'GATHERCONTENT_SLUG', 'gathercontent-import' );
 define( 'GATHERCONTENT_PLUGIN', __FILE__ );
 define( 'GATHERCONTENT_URL', plugin_dir_url( __FILE__ ) );

--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -62,7 +62,7 @@ function setup() {
 		return __NAMESPACE__ . "\\$function";
 	};
 
-	spl_autoload_register( $n( 'autoload' ), false );
+	spl_autoload_register($n( 'autoload' ));
 
 	include_once GATHERCONTENT_PATH . 'vendor/autoload.php';
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gathercontent-importer",
   "title": "GatherContent Plugin",
   "description": "Imports items from GatherContent to your wordpress site",
-  "version": "3.2.16",
+  "version": "3.2.17",
   "license": "GPLv2",
   "homepage": "http://www.gathercontent.com",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: gathercontent, mathew-chapman, namshee, justinsainton
 Donate link: http://www.gathercontent.com
 Tags: structured content, gather content, gathercontent, import, migrate, export, mapping, production, writing, collaboration, platform, connect, link, gather, client, word, production
 Requires at least: 5.6.0
-Tested up to: 6.1
-Stable tag: 3.2.16
+Tested up to: 6.3
+Stable tag: 3.2.17
 License: GPL-2.0+
 Requires PHP: 7.0
 License URI: https://opensource.org/licenses/GPL-2.0
@@ -64,6 +64,9 @@ Below the text box is a button that will allow you to simply save all of that in
 6. Or change the item's GatherContent status in quick-edit mode.
 
 == Changelog ==
+
+= 3.2.17 =
+* Updated spl_autoload_register to be PHP8 compatible
 
 = 3.2.16 =
 * Reformatting version file


### PR DESCRIPTION
Customer is reporting the following errors when running: 
- 8.1.13: https://share.getcloudapp.com/BluzAoL6
- 8.2: https://share.getcloudapp.com/E0uLvgW1


