### PR TITLE
Removing references to deprecated WPSEO_Social_Admin constructor class

### DIFF
--- a/includes/classes/admin/mapping/field-types/wpseo.php
+++ b/includes/classes/admin/mapping/field-types/wpseo.php
@@ -127,10 +127,6 @@ class WPSEO extends Base implements Type {
 		new \WPSEO_Metabox();
 		\WPSEO_Metabox::translate_meta_boxes();
 
-		if ( $options['opengraph'] === true || $options['twitter'] === true || $options['googleplus'] === true ) {
-			new \WPSEO_Social_Admin();
-			\WPSEO_Social_Admin::translate_meta_boxes();
-		}
 	}
 
 	public function remove_wpseo_keys( $blacklist ) {


### PR DESCRIPTION

* WPSEO_Social_Admin class was deprecated back in 2020. Recent versions of WPSEO/Yoast plugin no longer support it and it was causing a fatal issue when both gathercontent-import and yoast were active.
* Since there was no functionality within gathercontent-import associated with this deprecated class, removed the references to it to avoid errors with no loss of value.