### PR TITLE
rendering html for data.post_title

### DIFF
--- a/includes/views/tmpl-gc-item.php
+++ b/includes/views/tmpl-gc-item.php
@@ -19,7 +19,7 @@
 	<# if ( '&mdash;' === data.post_title ) { #>
 		&mdash;
 	<# } else { #>
-		{{ data.post_title }}
+		{{{ data.post_title }}}
 	<# } #>
 	<# if ( data.editLink ) { #></a><# } #>
 </td>


### PR DESCRIPTION
special characters in data.post_title was getting escaped, changed how that data was rendered within the underscore template to show raw data