### PR TITLE
Addresses some dynamic properties triggering deprecations in php8.2

### DIFF
--- a/includes/classes/admin/base.php
+++ b/includes/classes/admin/base.php
@@ -42,7 +42,7 @@ abstract class Base extends Enqueue {
 	public $default_options = array();
 
 	/** @var string $logo */
-	public $logo;
+	protected $logo;
 
 	/**
 	 * Creates an instance of this class.

--- a/includes/classes/admin/base.php
+++ b/includes/classes/admin/base.php
@@ -41,6 +41,9 @@ abstract class Base extends Enqueue {
 	 */
 	public $default_options = array();
 
+	/** @var string $logo */
+	public $logo;
+
 	/**
 	 * Creates an instance of this class.
 	 *

--- a/includes/classes/admin/post-base.php
+++ b/includes/classes/admin/post-base.php
@@ -54,6 +54,9 @@ abstract class Post_Base extends UI_Base {
 	 */
 	protected $doing_ajax = false;
 
+	/** @var array $post_types */
+	protected $post_types = [];
+
 	/**
 	 * Creates an instance of this class.
 	 *

--- a/includes/classes/sync/base.php
+++ b/includes/classes/sync/base.php
@@ -91,6 +91,9 @@ abstract class Base extends Plugin_Base {
 	 */
 	protected $append_types = array( 'post_content', 'post_title', 'post_excerpt' );
 
+	/** @var Log $log */
+	protected $logger;
+
 	/**
 	 * Creates an instance of this class.
 	 *


### PR DESCRIPTION
```

Deprecated: Creation of dynamic property GatherContent\Importer\Admin\Admin::$logo
    is deprecated in /var/www/html/wp-content/plugins/gathercontent-import/includes/classes/admin/base.php on line 53
Deprecated: Creation of dynamic property GatherContent\Importer\Admin\Mapping_Wizard::$logo
    is deprecated in /var/www/html/wp-content/plugins/gathercontent-import/includes/classes/admin/base.php on line 53
Deprecated: Creation of dynamic property GatherContent\Importer\Sync\Pull::$logger
    is deprecated in /var/www/html/wp-content/plugins/gathercontent-import/includes/classes/sync/base.php on line 105
Deprecated: Creation of dynamic property GatherContent\Importer\Sync\Push::$logger
    is deprecated in /var/www/html/wp-content/plugins/gathercontent-import/includes/classes/sync/base.php on line 105
Deprecated: Creation of dynamic property GatherContent\Importer\Admin\Bulk::$post_types
    is deprecated in /var/www/html/wp-content/plugins/gathercontent-import/includes/classes/admin/bulk.php on line 52
Deprecated: Creation of dynamic property GatherContent\Importer\Admin\Single::$post_types
    is deprecated in /var/www/html/wp-content/plugins/gathercontent-import/includes/classes/admin/single.php on line 60 Warning: Cannot modify header information 
```