### PR TITLE
[GC-4107] Integration functions in PHP 8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "minimum-stability": "dev",
   "require": {
-    "php": ">=7.0",
+    "php": "~7.0 || ~8.0",
     "techcrunch/wp-async-task": "dev-master",
     "ralouphie/mimey": "^1.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   ],
   "minimum-stability": "dev",
   "require": {
-    "php": "~7.0 || ~8.0",
+    "php": "~7.0 || 8.0 - 8.3.*",
     "techcrunch/wp-async-task": "dev-master",
     "ralouphie/mimey": "^1.0"
   },


### PR DESCRIPTION
Updates the `composer.json` to enforce `7.x` or `8.0 - 8.3.*` versions.

Functions as expected in an 8.3 environment.

Works out of the box as the only non-dev requirements are friendly to higher levels of php:
- `techcrunch/wp-async-task` no php requirement (single script very vanilla old school php)
- `ralouphie/mimey` requires `>=5.3`

## Tested locally for:
- Login
- Create new mappings
- Open and edit new mappings
- Pull & Push from in-post editor