### PR TITLE
[WIP] [GC-4623] AIOSEO plugin

### DIFF
--- a/includes/classes/admin/mapping-wizard.php
+++ b/includes/classes/admin/mapping-wizard.php
@@ -696,6 +696,8 @@ class Mapping_Wizard extends Base {
 	 * @return void
 	 */
 	protected function save_mapping_post_and_redirect( $project, $template, $options ) {
+			//TODO Gavin - I think this is where the save happens
+
 		if ( ! wp_verify_nonce( $options['create_mapping'], md5( $project . $template ) ) ) {
 
 			// Let check_admin_referer handle the fail.

--- a/includes/classes/admin/mapping/base.php
+++ b/includes/classes/admin/mapping/base.php
@@ -8,6 +8,7 @@
 namespace GatherContent\Importer\Admin\Mapping;
 
 use GatherContent\Importer\Base as Plugin_Base;
+use Symfony\Component\Console\Helper\Table;
 
 /**
  * Class for managing syncing template items.
@@ -198,6 +199,31 @@ abstract class Base extends Plugin_Base {
 		}
 
 		return $select_options;
+	}
+
+	/**
+	 * @return Array<string, string[]> - array of table names prefixed with wp_
+	 */
+	protected function database_types(){
+		global $wpdb;
+
+		$wpTables = $wpdb->get_col("SHOW TABLES LIKE '{$wpdb->prefix}%'");
+
+		$allColumns = [];
+		foreach($wpTables as $tableName){
+			if(!isset($allColumns[$tableName])){
+				$allColumns[$tableName] = [];
+			}
+
+			$tableCols = $wpdb->get_results("SHOW COLUMNS FROM $tableName");
+
+			foreach($tableCols as $tableCol){
+				$str = "$tableCol->Field ($tableCol->Type)";
+				$allColumns[$tableName][] = $str;
+			}
+		}
+
+		return $allColumns;
 	}
 
 	/**

--- a/includes/classes/admin/mapping/base.php
+++ b/includes/classes/admin/mapping/base.php
@@ -218,7 +218,7 @@ abstract class Base extends Plugin_Base {
 			$tableCols = $wpdb->get_results("SHOW COLUMNS FROM $tableName");
 
 			foreach($tableCols as $tableCol){
-				$str = "$tableCol->Field ($tableCol->Type)";
+				$str = "$tableCol->Field";
 				$allColumns[$tableName][] = $str;
 			}
 		}

--- a/includes/classes/admin/mapping/field-types/database.php
+++ b/includes/classes/admin/mapping/field-types/database.php
@@ -1,0 +1,96 @@
+<?php
+namespace GatherContent\Importer\Admin\Mapping\Field_Types;
+
+use GatherContent\Importer\Views\View;
+
+class Database extends Base implements Type {
+
+	/**
+	 * Array of supported template field types.
+	 *
+	 * @var array
+	 */
+	protected $supported_types = array(
+		'text',
+		'text_rich',
+		'text_plain',
+		'choice_radio',
+	);
+
+	protected $type_id      = 'wp-type-database';
+	protected $post_options = array();
+
+	protected $tableColumnData = [];
+
+	/**
+	 * Creates an instance of this class.
+	 *
+	 * @since 3.0.0
+	 */
+	public function __construct( array $post_options ) {
+		$this->tableColumnData = $post_options;
+		$this->post_options = array_keys($this->tableColumnData);
+		$this->option_label = __( 'Database', 'gathercontent-import' );
+	}
+
+	private function getAllTableColOptions()
+	{
+		$allOpts = [];
+
+		foreach ($this->tableColumnData as $tableName => $columns) {
+			$allOpts = array_merge($allOpts, $this->getTableColOptions($tableName));
+		}
+
+		return $allOpts;
+	}
+
+	private function getTableColOptions(string $tableName)
+	{
+		$optionStrings = [];
+
+		foreach ($this->tableColumnData[$tableName] as $column) {
+			$optionStrings[] = "<option style='display: none' data-tablename='$tableName' value='{$column}'>{$column}</option>";
+		}
+
+		return $optionStrings;
+	}
+
+	public function underscore_template( View $view ) {
+
+		//TODO Gavin this cannot be the done way of adding on-page js. Do it properly.
+		$mainSelectOnChangeJavascript = <<<EOT
+/** @type {HTMLSelectElement} selectElement */
+const selectElement = this
+const value = selectElement.value
+
+// get the selected options text
+const text = selectElement.options[selectElement.selectedIndex].text
+
+// get the sub-selector and clear any selection
+const subSelectElement = document.querySelector('select[name=\'temp-test\']')
+subSelectElement.value = ''
+
+// hide any option whose data-tablename is not this text
+subSelectElement.querySelectorAll('option').forEach(opt => {
+	const optTableName = opt.getAttribute('data-tablename')
+
+	opt.style.display = optTableName === text ? 'block' : 'none'
+})
+EOT;
+
+		?>
+		<# if ( '<?php $this->e_type_id(); ?>' === data.field_type ) { #>
+			<select onchange="<?= $mainSelectOnChangeJavascript ?>" class="gc-select2 wp-type-value-select <?php $this->e_type_id(); ?>" name="<?php $view->output( 'option_base' ); ?>[mapping][{{ data.name }}][value]">
+				<?php $this->underscore_options( $this->post_options ); ?>
+				<?php $this->underscore_empty_option( __( 'Do Not Import', 'gathercontent-import' ) ); ?>
+			</select>
+<!--		//TODO Gavin how do we pass the selection down on submit?-->
+			<select name="temp-test" >
+				<option value="">Select a column</option>
+				<?= implode('\r\n', $this->getAllTableColOptions()) ?>
+			</select>
+		<# } #>
+		<?php
+	}
+
+}

--- a/includes/classes/admin/mapping/field-types/database.php
+++ b/includes/classes/admin/mapping/field-types/database.php
@@ -29,7 +29,9 @@ class Database extends Base implements Type {
 	 */
 	public function __construct( array $post_options ) {
 		$this->tableColumnData = $post_options;
-		$this->post_options = array_keys($this->tableColumnData);
+
+		$tableNames = array_keys($this->tableColumnData);
+		$this->post_options = array_combine($tableNames, $tableNames);
 		$this->option_label = __( 'Database', 'gathercontent-import' );
 	}
 
@@ -57,6 +59,8 @@ class Database extends Base implements Type {
 
 	public function underscore_template( View $view ) {
 
+		$subValueName = $view->get( 'option_base' ) . '[mapping][0beda65c-779b-1970-ae99-4ecb696c8b01][sub-value]';
+
 		//TODO Gavin this cannot be the done way of adding on-page js. Do it properly.
 		$mainSelectOnChangeJavascript = <<<EOT
 /** @type {HTMLSelectElement} selectElement */
@@ -67,7 +71,7 @@ const value = selectElement.value
 const text = selectElement.options[selectElement.selectedIndex].text
 
 // get the sub-selector and clear any selection
-const subSelectElement = document.querySelector('select[name=\'temp-test\']')
+const subSelectElement = document.querySelector('select[name=\'$subValueName\']')
 subSelectElement.value = ''
 
 // hide any option whose data-tablename is not this text
@@ -85,7 +89,7 @@ EOT;
 				<?php $this->underscore_empty_option( __( 'Do Not Import', 'gathercontent-import' ) ); ?>
 			</select>
 <!--		//TODO Gavin how do we pass the selection down on submit?-->
-			<select name="temp-test" >
+			<select name="<?= $subValueName ?>" >
 				<option value="">Select a column</option>
 				<?= implode('\r\n', $this->getAllTableColOptions()) ?>
 			</select>

--- a/includes/classes/admin/mapping/field-types/types.php
+++ b/includes/classes/admin/mapping/field-types/types.php
@@ -14,6 +14,8 @@ class Types extends Plugin_Base {
 	 */
 	protected $core_types = array();
 
+	protected $sub_types = [];
+
 	/**
 	 * Array of Type
 	 *
@@ -26,8 +28,9 @@ class Types extends Plugin_Base {
 	 *
 	 * @since 3.0.0
 	 */
-	public function __construct( array $core_types ) {
+	public function __construct( array $core_types, array $sub_types ) {
 		$this->core_types = $core_types;
+		$this->sub_types = $sub_types;
 	}
 
 	/**
@@ -42,6 +45,8 @@ class Types extends Plugin_Base {
 			}
 
 			$this->field_types[ $type->type_id() ] = $type;
+			//TODO Gavin this is where the dropdowns are populated
+			//TODO gavin but where are the _Extra_ drop downs from?
 			add_action( 'gathercontent_field_type_option_underscore_template', array( $type, 'option_underscore_template' ) );
 			add_action( 'gathercontent_field_type_underscore_template', array( $type, 'underscore_template' ) );
 		}

--- a/includes/classes/admin/mapping/template-mapper.php
+++ b/includes/classes/admin/mapping/template-mapper.php
@@ -1,6 +1,7 @@
 <?php
 namespace GatherContent\Importer\Admin\Mapping;
 
+use GatherContent\Importer\Admin\Mapping\Field_Types\Types;
 use GatherContent\Importer\Utils;
 
 /**
@@ -233,18 +234,29 @@ class Template_Mapper extends Base {
 	 * @return Field_Types\Types object
 	 */
 	protected function initiate_mapped_field_types() {
+		$databaseType = new Field_Types\Database( $this->database_types());
+
 		$core_field_types = array(
 			new Field_Types\Post( $this->post_options() ),
 			new Field_Types\Taxonomy( $this->post_types() ),
 			new Field_Types\Meta(),
 			new Field_Types\Media(),
+			$databaseType,
 		);
 
 		if ( defined( 'WPSEO_VERSION' ) ) {
 			$core_field_types[] = new Field_Types\WPSEO( $this->post_types() );
 		}
 
-		$type = new Field_Types\Types( $core_field_types );
+		$sub_field_types = [
+			$databaseType->type_id() => [
+				'foo',
+				'bar',
+				'fizz',
+			],
+		];
+
+		$type = new Field_Types\Types( $core_field_types, $sub_field_types );
 
 		return $type->register();
 	}

--- a/includes/classes/post-types/template-mappings.php
+++ b/includes/classes/post-types/template-mappings.php
@@ -384,6 +384,7 @@ class Template_Mappings extends Base {
 	}
 
 	public static function create_mapping( $mapping_args, $post_data = array(), $wp_error = false ) {
+
 		$mapping_args = wp_parse_args(
 			$mapping_args,
 			array(
@@ -405,6 +406,10 @@ class Template_Mappings extends Base {
 			);
 		}
 
+		//TODO we need to do the insert here!
+		// but then how do we ensure that it's updated when gathercontent sync
+		// is done?
+
 		$post_data = wp_parse_args(
 			$post_data,
 			array(
@@ -420,6 +425,8 @@ class Template_Mappings extends Base {
 				),
 			)
 		);
+
+		var_dump(['CREATE MAPPING', $post_data]);
 
 		return wp_insert_post( $post_data, $wp_error );
 	}

--- a/includes/views/tabs-wrapper.php
+++ b/includes/views/tabs-wrapper.php
@@ -15,6 +15,8 @@
 		</fieldset>
 	<?php endforeach; ?>
 
+	<p>foobar</p>
+
 	<?php $this->output( 'after_tabs_wrapper' ); ?>
 
 </div>

--- a/includes/views/tabs-wrapper.php
+++ b/includes/views/tabs-wrapper.php
@@ -15,7 +15,7 @@
 		</fieldset>
 	<?php endforeach; ?>
 
-	<p>foobar</p>
+<!--	<p>foobar</p>-->
 
 	<?php $this->output( 'after_tabs_wrapper' ); ?>
 

--- a/includes/views/tmpl-gc-mapping-tab-row.php
+++ b/includes/views/tmpl-gc-mapping-tab-row.php
@@ -24,6 +24,6 @@
 		<option <# if ( '' === data.field_type ) { #>selected="selected"<# } #> value=""><?php _e( 'Unused', 'gathercontent-import' ); ?></option>
 		<?php do_action( 'gathercontent_field_type_option_underscore_template', $this ); ?>
 	</select>
-
+<!-- //TODO this is the area where the drop downs are populated -->
 	<?php do_action( 'gathercontent_field_type_underscore_template', $this ); ?>
 </td>


### PR DESCRIPTION
Work in progress.

See new class `\GatherContent\Importer\Admin\Mapping\Field_Types\Database` which provides the drop-down data for selecting db table -> column.

Of note is the method `\GatherContent\Importer\Admin\Mapping\Field_Types\Database::underscore_template` which uses _horrendous_ in-line js to update the sub-dropdown with the table columns whenever the table drop-down is changed.

I assume there is a better Wordpress-y way of doing this.

Also of note is `\GatherContent\Importer\Admin\Mapping_Wizard::save_mapping_post_and_redirect` which is where the form submission is handled and in turn calls `\GatherContent\Importer\Post_Types\Template_Mappings::create_mapping`

Current task was to suss out how to update this method to take in the new name attribute for the database table & column dropdowns.

# Note

For whatever reason I was unable to observe AIOSEO working in it's normal way. Possibly this is an artefact of my local environment that I do not understand, it's own tables would not update with any content from CW either initially nor on content changes re-syncing.