### PR TITLE
Fix type checking for checkbox when importing from GatherContent

### DIFF
--- a/includes/classes/sync/pull.php
+++ b/includes/classes/sync/pull.php
@@ -625,7 +625,15 @@ class Pull extends Base {
 		if ( 'text' === $this->element->type ) {
 			$terms = array_map( 'trim', explode( ',', sanitize_text_field( $this->element->value ) ) );
 		} elseif ( 'choice_checkbox' === $this->element->type ) {
-			$terms = json_decode($this->element->value);
+			$element_value = $this->element->value;
+
+			// If no terms are selected, $this->element->value may be an empty PHP array instead of a string
+			if (empty($element_value)) {
+				$terms = array();
+			}
+			else {
+				$terms = json_decode($this->element->value);
+			}
 		} else {
 			$terms = (array) $this->element->value;
 		}


### PR DESCRIPTION
When importing an item with a custom taxonomy that is a checkbox field, if no terms are checked in GatherContent, the import will fail (it will hang at 0% when importing through the Template Mappings page). For some reason, `this->element->value` in the code block I edited is an empty PHP array if no terms are checked, and a JSON-formatted string otherwise. 

I added a small fix here to check if it is an empty array, but I assume the GatherContent development team may want to look into the root cause of this.

I made this change on my WordPress installation and it fixed the issue.